### PR TITLE
添加对azure openai的支持

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -43,6 +43,7 @@
     "open_ai_api_key": "",
     "model": "gpt-3.5-turbo",
     "open_ai_api_base": "https://api.openai.com/v1",
+    "azure_deployment_id": "",
     "xunfei_app_id": "",
     "xunfei_api_key": "",
     "xunfei_api_secret": "",

--- a/sum4all.py
+++ b/sum4all.py
@@ -330,7 +330,7 @@ class sum4all(Plugin):
     def handle_url(self, content, e_context):
         logger.info('Handling Sum4All request...')
         # 根据sum_service的值选择API密钥和基础URL
-        if self.url_sum_service == "openai" or self.url_sum_service == "azure":
+        if self.url_sum_service == "openai":
             api_key = self.open_ai_api_key
             api_base = self.open_ai_api_base
             model = self.model
@@ -474,7 +474,7 @@ class sum4all(Plugin):
         e_context.action = EventAction.BREAK_PASS    
     def handle_search(self, content, e_context):
         # 根据sum_service的值选择API密钥和基础URL
-        if self.search_sum_service == "openai" or self.search_sum_service == "azure":
+        if self.search_sum_service == "openai":
             api_key = self.open_ai_api_key
             api_base = self.open_ai_api_base
             model = self.model
@@ -586,9 +586,13 @@ class sum4all(Plugin):
     def handle_file(self, content, e_context):
         logger.info("handle_file: 向LLM发送内容总结请求")
         # 根据sum_service的值选择API密钥和基础URL
-        if self.file_sum_service == "openai" or self.file_sum_service == "azure":
+        if self.file_sum_service == "openai":
             api_key = self.open_ai_api_key
             api_base = self.open_ai_api_base
+            model = self.model
+        elif self.file_sum_service == "azure":
+            api_key = self.open_ai_api_key
+            api_base = f"{self.open_ai_api_base}/openai/deployments/{self.azure_deployment_id}/chat/completions?api-version=2024-02-15-preview"
             model = self.model
         elif self.file_sum_service == "sum4all":
             api_key = self.sum4all_key
@@ -619,6 +623,19 @@ class sum4all(Plugin):
             "generationConfig": {
                 "maxOutputTokens": 800
             }
+            }
+            api_url = api_base
+        elif self.file_sum_service == "azure":
+            headers = {
+                "Content-Type": "application/json",
+                "api-key": api_key
+            }
+            data = {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": content}
+                ]
             }
             api_url = api_base
         else:


### PR DESCRIPTION
azure的调用方式和openai基本一致，区别在于提交请求时headers格式不同

因此可以复用openai的代码，仅在最后提交时重新构造headers格式

配置项中，原本的`open_ai_api_key` `model` `open_ai_api_base`分别对应azure的key、model和endpoint

此外增加了azure独有的自定义部署名`azure_deployment_id`

配置示例如下：

![图片](https://github.com/user-attachments/assets/d2f49f1e-cc26-4072-ad93-92b97465d6aa)
